### PR TITLE
catch client error and add more details to the message

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -103,6 +103,11 @@ class HttpClient
 
         try {
             $response = $this->client->send($request);
+        } catch (ClientErrorResponseException $e) {
+            $responseBody = $e->getResponse()->getBody(true);
+            throw new RuntimeException(
+                sprintf('%s\n[body] %s', $e->getMessage(),$responseBody), $e->getCode(), $e
+            );
         } catch (\LogicException $e) {
             throw new ErrorException($e->getMessage(), $e->getCode(), $e);
         } catch (\RuntimeException $e) {


### PR DESCRIPTION
Before:
`[status code] 422
[reason phrase] Unprocessable Entity
[url] https://shineon-diogo-test.myshopify.com/admin/products/153585385485/variants.json,
"file_line":"/home/vagrant/fulfillment.shineon.com/vendor/dan/shopify-api/src/HttpClient.php:137",`

After:
`[status code] 422
[reason phrase] Unprocessable Entity
[url] https://shineon-diogo-test.myshopify.com/admin/products/153585385485/variants.json\
[body] {\"errors\":{\"base\":[\"The variant 'R3 S\\/M -Luxury Charm Bracelet (18cm)' already exists.\"]}}",
"file_line":"/home/vagrant/fulfillment.shineon.com/vendor/dan/shopify-api/src/HttpClient.php:137",`