### PR TITLE
Allow calling update method on models

### DIFF
--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -301,7 +301,7 @@ abstract class AbstractModel implements JsonSerializable
      *
      * @return $this
      */
-    protected function update()
+    public function update()
     {
         $this->preUpdate();
         $this->data = $this->api->update($this->id, $this->data);

--- a/src/Models/Metafield.php
+++ b/src/Models/Metafield.php
@@ -88,7 +88,7 @@ class Metafield extends AbstractModel
      *
      * @return $this
      */
-    protected function create()
+    public function create()
     {
         $this->preCreate();
         if ($this->owner_resource) {

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -258,7 +258,7 @@ class Shop extends AbstractModel
      * @return $this
      * @throws \BadMethodCallException
      */
-    protected function update()
+    public function update()
     {
         throw new BadMethodCallException("Method not allowed on Shop resource.");
     }


### PR DESCRIPTION
Save method makes an extra API call at the end `$this->refresh();`
Making update method public will allow us to save that extra API call.